### PR TITLE
Use lodash-webpack-plugin.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "babel": "inherit"
   },
   "babel": {
+    "plugins": [
+      "lodash"
+    ],
     "presets": [
       "es2015"
     ]
@@ -44,16 +47,18 @@
   "license": "MIT",
   "devDependencies": {
     "ava": "^0.16.0",
-    "babel-core": "^6.11.4",
-    "babel-loader": "^6.2.4",
-    "babel-preset-es2015": "^6.9.0",
+    "babel-core": "^6.14.0",
+    "babel-loader": "^6.2.5",
+    "babel-plugin-lodash": "^3.2.8",
+    "babel-preset-es2015": "^6.14.0",
     "babel-register": "^6.11.6",
     "eslint": "^3.3.1",
     "http-server": "^0.9.0",
+    "lodash-webpack-plugin": "^0.10.0",
     "node-sass": "^3.8.0",
-    "webpack": "^1.13.1"
+    "webpack": "^1.13.2"
   },
   "dependencies": {
-    "lodash": "^4.14.2"
+    "lodash": "^4.15.0"
   }
 }

--- a/src/in-view.js
+++ b/src/in-view.js
@@ -1,5 +1,5 @@
 import Registry from './registry';
-import throttle from 'lodash/throttle';
+import { throttle } from 'lodash';
 
 /**
 * Check whether an element is in the viewport by
@@ -39,11 +39,11 @@ const inView = () => {
     * which checks each registry, throttled to threshold.
     */
     triggers.forEach(event =>
-        window.addEventListener(event, throttle(() => {
+        addEventListener(event, throttle(() => {
             selectors.history.forEach(selector => {
                 selectors[selector].check(offset);
             });
-        }, threshold, { trailing: true })));
+        }, threshold)));
 
     /**
     * The main interface. Take a selector and retrieve

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,25 +1,27 @@
-const webpack = require('webpack'),
+const LodashModuleReplacementPlugin = require('lodash-webpack-plugin'),
+      webpack = require('webpack'),
       package = require('./package');
 
 const banner = `${package.name} ${package.version} - ${package.description}\nCopyright (c) ${ new Date().getFullYear() } ${package.author} - ${package.homepage}\nLicense: ${package.license}`;
 
 module.exports = {
-    context: __dirname + '/src',
-    entry: './index.js',
-    output: {
-        path: __dirname + '/dist',
-        filename: `${package.name}.min.js`,
+    'context': __dirname + '/src',
+    'entry': './index.js',
+    'output': {
+        'path': __dirname + '/dist',
+        'filename': `${package.name}.min.js`,
         'library': `inView`,
         'libraryTarget': 'umd'
     },
-    module: {
-        loaders: [{
-            test: /\.js$/,
-            exclude: /node_modules/,
-            loader: 'babel-loader'
+    'module': {
+        'loaders': [{
+            'test': /\.js$/,
+            'exclude': /node_modules/,
+            'loader': 'babel'
         }]
     },
-    plugins: [
-        new webpack.BannerPlugin(banner)
+    'plugins': [
+        new webpack.BannerPlugin(banner),
+        new LodashModuleReplacementPlugin
     ]
 };


### PR DESCRIPTION
This adds lodash-webpack-plugin resulting in a build of 1.84 kB (gzipped).

BTW I saw the comments on HN. With your current setup the difference between lodash/throttle and Nat's naive untested version is ~0.5 kB. So hardly anything.  😉