### PR TITLE
use control.is as inViewport check in registry

### DIFF
--- a/src/in-view.js
+++ b/src/in-view.js
@@ -65,7 +65,7 @@ const inView = () => {
 
         // If it doesn't exist, create a new registry.
         else {
-            selectors[selector] = Registry(elements);
+            selectors[selector] = Registry(elements, (...args) => control.is(...args));
             selectors.history.push(selector);
         }
 

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,4 +1,4 @@
-import { inViewport } from './viewport';
+import { inViewport as _inViewport } from './viewport';
 
 /**
 * - Registry -
@@ -9,11 +9,12 @@ import { inViewport } from './viewport';
 
 class inViewRegistry {
 
-    constructor(elements) {
+    constructor(elements, inViewport) {
         this.current  = [];
         this.elements = elements;
         this.handlers = { enter: [], exit: [] };
         this.singles  = { enter: [], exit: [] };
+        this.inViewport = inViewport;
     }
 
     /**
@@ -23,7 +24,7 @@ class inViewRegistry {
     check(offset) {
         this.elements.forEach(el => {
 
-            let passes  = inViewport(el, offset);
+            let passes  = this.inViewport(el, offset);
             let index   = this.current.indexOf(el);
             let current = index > -1;
             let entered = passes && !current;
@@ -78,4 +79,4 @@ class inViewRegistry {
 
 }
 
-export default (elements) => new inViewRegistry(elements);
+export default (elements, inViewport = _inViewport) => new inViewRegistry(elements, inViewport);

--- a/test/registry.spec.js
+++ b/test/registry.spec.js
@@ -2,11 +2,13 @@ import test from 'ava';
 import Registry from '../src/registry';
 
 test('Registry returns a registry', t => {
-    let registry = Registry([document.body]);
+    let inViewport = () => {};
+    let registry = Registry([document.body], inViewport);
     t.deepEqual(registry, {
         current: [],
         elements: [document.body],
         handlers: { enter: [], exit: [] },
-        singles: { enter: [], exit: [] }
+        singles: { enter: [], exit: [] },
+        inViewport
     });
 });


### PR DESCRIPTION
as requested in issue #24 here’s the implementation :)

the adapted test in registry.spec should be sufficient in my opinion as the identity of the inViewport function is checked and the inViewport stub proves that you can overwrite it.

if you want additional documentation for this feature, feel free to add it yourself or tell me what kind you have in mind.

I’m looking forward to v0.5.0 :)