### PR TITLE
Increase Performance on Docs, Remove Absolute Positioning

### DIFF
--- a/docs/lib/css/main.scss
+++ b/docs/lib/css/main.scss
@@ -97,19 +97,18 @@ a {
     z-index: 1;
 }
 
-.dot {
+.dot::after {
+    display: block;
+    content: " ";
     background-color: rgba($color-red, 0.75);
     border-radius: 50%;
     height: 2.5rem;
-    left: 0;
-    position: absolute;
-    top: 0;
     width: 2.5rem;
     -webkit-transition: background-color 0.2s $easing-outExpo, -webkit-transform 0.2s $easing-outExpo;
             transition: background-color 0.2s $easing-outExpo, transform 0.2s $easing-outExpo;
 }
 
-.dot.in-view {
+.dot.in-view::after {
     background-color: rgba($color-blue, 0.75);
     -webkit-transform: scale(2);
             transform: scale(2);

--- a/docs/lib/js/main.js
+++ b/docs/lib/js/main.js
@@ -3,16 +3,24 @@ import inView from '../../../src';
 let count = 200;
 let field = document.querySelector('.field');
 
+const getRandomInt = (min, max) => {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
 const createDot = () => {
-    let dot = document.createElement('div');
-    dot.className = 'dot';
-    dot.style.top = `${(Math.random() * 100)}%`;
-    dot.style.left = `${(Math.random() * 100)}%`;
-    return dot;
+  let dot = document.createElement('div');
+  dot.className = 'dot';
+
+  const translateX = getRandomInt(0, field.offsetWidth);
+  const translateY = getRandomInt(0, field.offsetHeight);
+
+  dot.style.transform = `translate(${translateX}px, ${translateY}px)`;
+
+  return dot;
 }
 
 while (count--) {
-    field.appendChild(createDot());
+  field.appendChild(createDot());
 }
 
 inView.offset(50);

--- a/docs/lib/js/main.js
+++ b/docs/lib/js/main.js
@@ -10,12 +10,7 @@ const getRandomInt = (min, max) => {
 const createDot = () => {
   let dot = document.createElement('div');
   dot.className = 'dot';
-
-  const translateX = getRandomInt(0, field.offsetWidth);
-  const translateY = getRandomInt(0, field.offsetHeight);
-
-  dot.style.transform = `translate(${translateX}px, ${translateY}px)`;
-
+  dot.style.transform = `translate(${getRandomInt(0, 100)}%, ${getRandomInt(0, 100)}%)`;
   return dot;
 }
 


### PR DESCRIPTION
The absolute positioning used on the documentation page was causing very poor performance on Firefox (less noticeable on Chrome). 

### Scrolling Before

Scrolling in FF was choppy and there's a significant delay for the `in-view` class to be added.

![ff-before](https://user-images.githubusercontent.com/692538/36229150-2f767a04-118b-11e8-97a9-b53b431e69d2.gif)

### Scrolling After

![ff-after](https://user-images.githubusercontent.com/692538/36229155-352ca306-118b-11e8-8f09-0aecc1e90de1.gif)

I've updated the JS to use `translate(x,y)` for the dots instead of absolute positioning. To avoid JS overwriting the CSS transforms for dots that are in-view, dot styles are applied to the `::after` pseudo element. This will increase performance for both chrome and FF.
